### PR TITLE
fix: devops link

### DIFF
--- a/.github/ISSUE_TEMPLATE/c_epic.md
+++ b/.github/ISSUE_TEMPLATE/c_epic.md
@@ -7,6 +7,8 @@ version: "v1.0.1"
 
 ## Summary
 
+DevOps link: `none` <!-- Example: AB#<item_number> -->
+
 ## Acceptance criteria
 - 
 

--- a/.github/ISSUE_TEMPLATE/c_epic_maintenance.md
+++ b/.github/ISSUE_TEMPLATE/c_epic_maintenance.md
@@ -6,6 +6,8 @@ title: "\U0001f451 e-<team_alias>: Maintenance 2024"
 
 ## Summary
 
+DevOps link: `none` <!-- Example: AB#<item_number> -->
+
 This Epic represents all Collections and single tasks for maintenance. This is a place where we can set together Collections for all types: Monitoring, IaC, Backup and Disaster Recovery.
 
 ## Acceptance Criteria

--- a/.github/ISSUE_TEMPLATE/d_collection.md
+++ b/.github/ISSUE_TEMPLATE/d_collection.md
@@ -6,6 +6,8 @@ title: "\U0001f4c7 c-<team_alias>:"
 
 ## Summary
 
+DevOps link: `none` <!-- Example: AB#<item_number> -->
+
 ## Tasks
 
 - [ ] 

--- a/.github/ISSUE_TEMPLATE/e_task.md
+++ b/.github/ISSUE_TEMPLATE/e_task.md
@@ -6,6 +6,8 @@ title: ''
 
 ## Summary
 
+> DevOps link: `none` <!-- Example: AB#<item_number> -->
+
 ## To do
 
 - [ ]


### PR DESCRIPTION
We need to be able to link the Azure DevOps work items. This will make it easier to remember and fill the needed info every time someone create a new issue.