### PR TITLE
devops link suggestion

### DIFF
--- a/.github/ISSUE_TEMPLATE/c_epic.md
+++ b/.github/ISSUE_TEMPLATE/c_epic.md
@@ -7,7 +7,7 @@ version: "v1.0.1"
 
 ## Summary
 
-DevOps link: `none` <!-- Example: AB#<item_number> -->
+DevOps link: none <!-- Example: AB#<item_number> -->
 
 ## Acceptance criteria
 - 

--- a/.github/ISSUE_TEMPLATE/c_epic_maintenance.md
+++ b/.github/ISSUE_TEMPLATE/c_epic_maintenance.md
@@ -6,7 +6,7 @@ title: "\U0001f451 e-<team_alias>: Maintenance 2024"
 
 ## Summary
 
-DevOps link: `none` <!-- Example: AB#<item_number> -->
+DevOps link: none <!-- Example: AB#<item_number> -->
 
 This Epic represents all Collections and single tasks for maintenance. This is a place where we can set together Collections for all types: Monitoring, IaC, Backup and Disaster Recovery.
 

--- a/.github/ISSUE_TEMPLATE/d_collection.md
+++ b/.github/ISSUE_TEMPLATE/d_collection.md
@@ -6,7 +6,7 @@ title: "\U0001f4c7 c-<team_alias>:"
 
 ## Summary
 
-DevOps link: `none` <!-- Example: AB#<item_number> -->
+DevOps link: none <!-- Example: AB#<item_number> -->
 
 ## Tasks
 

--- a/.github/ISSUE_TEMPLATE/e_task.md
+++ b/.github/ISSUE_TEMPLATE/e_task.md
@@ -6,7 +6,7 @@ title: ''
 
 ## Summary
 
-> DevOps link: `none` <!-- Example: AB#<item_number> -->
+> DevOps link: none <!-- Example: AB#<item_number> -->
 
 ## To do
 


### PR DESCRIPTION
Adding the devops link in `code` form does create the link, and it is visible in DevOps, but it is not clickable from the GH issue which is impractical.
I suggest we remove the `` around none and leave it as plaintext for clarity?