### PR TITLE
fix: task github link

### DIFF
--- a/.github/ISSUE_TEMPLATE/e_task.md
+++ b/.github/ISSUE_TEMPLATE/e_task.md
@@ -12,7 +12,7 @@ Member of a Collection. Represents a single Pull Request or one manual operation
 
 ### Summary
 
-> DevOps link: none <!-- Example: AB#<item_number> -->
+DevOps link: `none` / AB#ticketNumber
 
 This task changes/maps/updates etc... <!-- Briefly explain task  -->
 


### PR DESCRIPTION
This change is meant to ease user experience when inputting a DevOps link and reduce the number of user inputs.

From: 
```
> DevOps link: none <!-- Example: AB#<item_number> -->
```
To:
```
DevOps link: `none` / AB#ticketNumber
```
There are two different scenarios:
1. You do have a DevOps ticket that you want to link.
2. You don't have a DevOps ticket that you want to link.

The current solution: 
Scenario 1. you have to remove the following:
* ">"
* "none <!-- Example:"
* "<item_number> -->"

Scenario 2. you have to remove the following:
* `>`
* ` <!-- Example: AB#<item_number> -->:`

The proposed solution:
Scenario 1. You have to do the following:
* Remove: "`none` /"
* Double click ticketNumber, and paste your ticket number.

Scenario 2.
* remove "/ AB#ticketNumber"
