### PR TITLE
fix: improved devops link

### DIFF
--- a/.github/ISSUE_TEMPLATE/c_epic.md
+++ b/.github/ISSUE_TEMPLATE/c_epic.md
@@ -11,7 +11,7 @@ This :crown: Epic represents all :card_index: Task Collections for one User Stor
 
 ### Summary
 
-DevOps link: `none` / AB#ticketNumber
+DevOps link: AB#ticketNumber
 
 This epic includes collections related to ..... <!-- Summarise overall reason/goal for epic -->
 

--- a/.github/ISSUE_TEMPLATE/c_epic_maintenance.md
+++ b/.github/ISSUE_TEMPLATE/c_epic_maintenance.md
@@ -10,7 +10,7 @@ This :crown: Epic represents all Collections and single tasks for maintenance in
 
 ### Summary
 
-DevOps link: `none` / AB#ticketNumber
+DevOps link: AB#ticketNumber
 
 This epic includes collections and tasks related to maintenance of "Goal"..... <!-- Summarise overall reason/goal for epic -->
 

--- a/.github/ISSUE_TEMPLATE/d_collection.md
+++ b/.github/ISSUE_TEMPLATE/d_collection.md
@@ -10,7 +10,7 @@ title: "\U0001f4c7 c-<team_alias>:"
 
 ### Summary
 
-DevOps link: `none` / AB#ticketNumber
+DevOps link: AB#ticketNumber
 
 This collection includes tasks related to..... <!-- Summarise overall reason for tasks in this collection -->
 

--- a/.github/ISSUE_TEMPLATE/d_collection_maintenance.md
+++ b/.github/ISSUE_TEMPLATE/d_collection_maintenance.md
@@ -12,7 +12,7 @@ This is a maintenance collection that contains one or more groups of tasks. Reme
 
 ### Summary
 
-DevOps link: `none` / AB#ticketNumber
+DevOps link: AB#ticketNumber
 
 This collection includes tasks related to maintenance of..... <!-- Summarise overall reason for tasks in this collection -->
 

--- a/.github/ISSUE_TEMPLATE/e_task.md
+++ b/.github/ISSUE_TEMPLATE/e_task.md
@@ -12,7 +12,7 @@ Member of a Collection. Represents a single Pull Request or one manual operation
 
 ### Summary
 
-DevOps link: `none` / AB#ticketNumber
+DevOps link: AB#ticketNumber
 
 This task changes/maps/updates etc... <!-- Briefly explain task  -->
 


### PR DESCRIPTION
Removed the `none` string from devops link. 

There are only two scenarios: 

A: You have a devops ticket, you link it
B: You do not have a devops ticket, you remove the entire line. 

In other words, the `none` text is not in use.